### PR TITLE
Fix broken navbar

### DIFF
--- a/prefs/HBListController.m
+++ b/prefs/HBListController.m
@@ -42,6 +42,10 @@
 		// really noticeable momentary freeze, which we really don’t want. work around this by warming
 		// PIDebianPackage on a background queue (with throttled I/O), reducing subsequent calls to a
 		// more tolerable duration (~70ms).
+		
+		HBAppearanceSettings *appearanceSettings = [[HBAppearanceSettings alloc] init];
+		self.hb_appearanceSettings = appearanceSettings;
+		
 #if !CEPHEI_EMBEDDED
 		static dispatch_once_t onceToken;
 		dispatch_once(&onceToken, ^{


### PR DESCRIPTION
HBAppearanceSettings inits all its default values in `- (instancetype)init` (including the crucial _translucentNavigationBar, in fact, that's the only thing it inits). However, for most HBListControllers, `hb_appearanceSettings` is never set, so when PSListController+HBTintAdditions.x accesses `self.hb_appearanceSettings.translucentNavigationBar` on line 96, `hb_appearanceSettings` is nil so `self.hb_appearanceSettings.translucentNavigationBar` is `NO` even though its default should be `YES`. The fix for this is just to set `hb_appearanceSettings` to a new instance of HBAppearanceSettings in HBListController's init so that `self.hb_appearanceSettings` is never `nil` and all the default values are read correctly.