### PR TITLE
Fix for dark/light mode on iOS 13

### DIFF
--- a/prefs/HBLinkTableCell.m
+++ b/prefs/HBLinkTableCell.m
@@ -28,6 +28,16 @@
 		self.detailTextLabel.numberOfLines = _isBig ? 0 : 1;
 		self.detailTextLabel.text = specifier.properties[@"subtitle"] ?: @"";
 		self.detailTextLabel.textColor = IS_IOS_OR_NEWER(iOS_7_0) ? [UIColor systemGrayColor] : [UIColor tableCellValue1BlueColor];
+		if (@available(iOS 13.0, *)) {
+			if (IS_IOS_OR_NEWER(iOS_13_0)) {
+				self.detailTextLabel.tintColor = [UIColor labelColor];
+			}
+		}
+		if (@available(iOS 13.0, *)) {
+			if (IS_IOS_OR_NEWER(iOS_13_0)) {
+				self.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+			}
+		}
 
 		if (self.shouldShowAvatar) {
 			CGFloat size = _isBig ? 38.f : 29.f;

--- a/prefs/HBLinkTableCell.m
+++ b/prefs/HBLinkTableCell.m
@@ -30,7 +30,7 @@
 		self.detailTextLabel.textColor = IS_IOS_OR_NEWER(iOS_7_0) ? [UIColor systemGrayColor] : [UIColor tableCellValue1BlueColor];
 		if (@available(iOS 13.0, *)) {
 			if (IS_IOS_OR_NEWER(iOS_13_0)) {
-				self.detailTextLabel.tintColor = [UIColor labelColor];
+				self.tintColor = [UIColor labelColor];
 			}
 		}
 		if (@available(iOS 13.0, *)) {


### PR DESCRIPTION
Should fix dark mode Link Cell bug on iOS 13 by properly using labelColor and secondaryLabelColor API added in iOS 13