### PR TITLE
Remove rocketbootstrap as a dependedency

### DIFF
--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ws.hbang.common
 Name: Cephei
-Depends: com.rpetrich.rocketbootstrap, firmware (>= 13.0) | jp.ashikase.techsupport
+Depends: firmware (>= 13.0) | com.rpetrich.rocketbootstrap, firmware (>= 13.0) | jp.ashikase.techsupport
 Version: 1.14
 Architecture: iphoneos-arm
 Description: Support library for tweaks


### PR DESCRIPTION
I tried installing Cephei on iOS 13 on Checkra1n with the Chimera bootstrap without rocketbootstrap installed on my phone and everything Cephei does still works from my testing. As Kirb said in this comment : https://www.reddit.com/r/jailbreak/comments/ehm7pq/update_axon_for_ios_13_originally_by/fcovaqf/ saying the only reason why rocketbootstrap couldn't be removed was because of Chimera but it appears as if that issue is fixed. 

Moreover, this was tested with the Binger's bootstrap on Unc0ver on iOS 13 and there were not problem there either. Tests were only done on iOS 13 hence the firmware check for greater than iOS 13 when choosing to eliminate rocketbootstrap.