### PR TITLE
incorrect null check

### DIFF
--- a/HBPreferencesCore.m
+++ b/HBPreferencesCore.m
@@ -258,7 +258,7 @@ static NSMutableDictionary <NSString *, HBPreferencesCore *> *KnownIdentifiers;
 }
 
 - (void)registerPreferenceChangeBlock:(HBPreferencesValueChangeCallback)callback forKey:(NSString *)key {
-	if (_preferenceChangeBlocks) {
+	if (!_preferenceChangeBlocks) {
 		_preferenceChangeBlocks = [[NSMutableDictionary alloc] init];
 	}
 


### PR DESCRIPTION
there seems to be a missing `!` when performing the null check on `_preferenceChangeBlocks`