### PR TITLE
Allow SFSymbols to be used from .plist

### DIFF
--- a/prefs/HBListController.m
+++ b/prefs/HBListController.m
@@ -61,7 +61,13 @@
 	return [self _hb_configureSpecifiers:specifiers];
 }
 
-- (UIImageSymbolWeight)symbolWeightWithString:(NSString *)weight {
+- (NSInteger)symbolWeightWithString:(NSString *)weight {
+	if ([weight isKindOfClass:NSNumber.class]) {
+		return [weight integerValue];
+	}
+	if (![weight isKindOfClass:NSString.class]) {
+		return UIImageSymbolWeightRegular;
+	}
 	if ([weight isEqualToString:@"UIImageSymbolWeightUltraLight"] || [weight isEqualToString:@"ultraLight"]) {
 		return UIImageSymbolWeightUltraLight;
 	}
@@ -89,7 +95,13 @@
 	return UIImageSymbolWeightRegular;
 }
 
-- (UIImageSymbolScale)symbolScaleWithString:(NSString *)scale {
+- (NSInteger)imageSystemScale:(id)scale {
+	if ([scaleValue isKindOfClass:NSNumber.class]) {
+		return [scaleValue integerValue];
+	}
+	if (![scaleValue isKindOfClass:NSString.class]) {
+		return UIImageSymbolScaleMedium;
+	}
 	if ([scale isEqualToString:@"UIImageSymbolScaleSmall"] || [scale isEqualToString:@"small"]) {
 		return UIImageSymbolScaleSmall;
 	}
@@ -99,30 +111,14 @@
 	if ([scale isEqualToString:@"UIImageSymbolScaleLarge"] || [scale isEqualToString:@"large"]) {
 		return UIImageSymbolScaleLarge;
 	}
-	return UIImageSymbolWeightRegular;
+	return UIImageSymbolScaleMedium;
 }
 
 - (UIImage *)imageSystemFromDict:(NSDictionary *)imageSystem {
-	UIImageSymbolWeight weight = UIImageSymbolWeightRegular;
-	id weightValue = iconImageSystem[@"weight"];
-	if ([weightValue isKindOfClass:NSString.class]) {
-		weight = [self symbolWeightWithString:weightValue];
-	} else if ([weightValue isKindOfClass:NSNumber.class]) {
-		weight = [weightValue integerValue];
-	}
-
-	UIImageSymbolScale scale = UIImageSymbolScaleMedium;
-	id scaleValue = iconImageSystem[@"scale"];
-	if ([scaleValue isKindOfClass:NSString.class]) {
-		scale = [self symbolScaleWithString:scaleValue];
-	} else if ([scaleValue isKindOfClass:NSNumber.class]) {
-		scale = [scaleValue integerValue];
-	}
-
 	UIImageSymbolConfiguration *configuration = [UIImageSymbolConfiguration
 		configurationWithPointSize:([imageSystem[@"pointSize"] floatValue] ?: 20.0)
-		weight:weight
-		scale:scale
+		weight:[self imageSystemWeight:weight]
+		scale:[self imageSystemScale:scale]
 	];
 
 	return [UIImage systemImageNamed:imageSystem[@"name"] withConfiguration:configuration];

--- a/prefs/HBListController.m
+++ b/prefs/HBListController.m
@@ -61,6 +61,73 @@
 	return [self _hb_configureSpecifiers:specifiers];
 }
 
+- (UIImageSymbolWeight)symbolWeightWithString:(NSString *)weight {
+	if ([weight isEqualToString:@"UIImageSymbolWeightUltraLight"] || [weight isEqualToString:@"ultraLight"]) {
+		return UIImageSymbolWeightUltraLight;
+	}
+	if ([weight isEqualToString:@"UIImageSymbolWeightThin"] || [weight isEqualToString:@"thin"]) {
+		return UIImageSymbolWeightThin;
+	}
+	if ([weight isEqualToString:@"UIImageSymbolWeightLight"] || [weight isEqualToString:@"light"]) {
+		return UIImageSymbolWeightLight;
+	}
+	if ([weight isEqualToString:@"UIImageSymbolWeightMedium"] || [weight isEqualToString:@"medium"]) {
+		return UIImageSymbolWeightMedium;
+	}
+	if ([weight isEqualToString:@"UIImageSymbolWeightSemibold"] || [weight isEqualToString:@"semiBold"]) {
+		return UIImageSymbolWeightSemibold;
+	}
+	if ([weight isEqualToString:@"UIImageSymbolWeightBold"] || [weight isEqualToString:@"bold"]) {
+		return UIImageSymbolWeightBold;
+	}
+	if ([weight isEqualToString:@"UIImageSymbolWeightHeavy"] || [weight isEqualToString:@"heavy"]) {
+		return UIImageSymbolWeightHeavy;
+	}
+	if ([weight isEqualToString:@"UIImageSymbolWeightBlack"] || [weight isEqualToString:@"black"]) {
+		return UIImageSymbolWeightBlack;
+	}
+	return UIImageSymbolWeightRegular;
+}
+
+- (UIImageSymbolScale)symbolScaleWithString:(NSString *)scale {
+	if ([scale isEqualToString:@"UIImageSymbolScaleSmall"] || [scale isEqualToString:@"small"]) {
+		return UIImageSymbolScaleSmall;
+	}
+	if ([scale isEqualToString:@"UIImageSymbolScaleMedium"] || [scale isEqualToString:@"medium"]) {
+		return UIImageSymbolScaleMedium;
+	}
+	if ([scale isEqualToString:@"UIImageSymbolScaleLarge"] || [scale isEqualToString:@"large"]) {
+		return UIImageSymbolScaleLarge;
+	}
+	return UIImageSymbolWeightRegular;
+}
+
+- (UIImage *)imageSystemFromDict:(NSDictionary *)imageSystem {
+	UIImageSymbolWeight weight = UIImageSymbolWeightRegular;
+	id weightValue = iconImageSystem[@"weight"];
+	if ([weightValue isKindOfClass:NSString.class]) {
+		weight = [self symbolWeightWithString:weightValue];
+	} else if ([weightValue isKindOfClass:NSNumber.class]) {
+		weight = [weightValue integerValue];
+	}
+
+	UIImageSymbolScale scale = UIImageSymbolScaleMedium;
+	id scaleValue = iconImageSystem[@"scale"];
+	if ([scaleValue isKindOfClass:NSString.class]) {
+		scale = [self symbolScaleWithString:scaleValue];
+	} else if ([scaleValue isKindOfClass:NSNumber.class]) {
+		scale = [scaleValue integerValue];
+	}
+
+	UIImageSymbolConfiguration *configuration = [UIImageSymbolConfiguration
+		configurationWithPointSize:([imageSystem[@"pointSize"] floatValue] ?: 20.0)
+		weight:weight
+		scale:scale
+	];
+
+	return [UIImage systemImageNamed:imageSystem[@"name"] withConfiguration:configuration];
+}
+
 - (NSMutableArray *)_hb_configureSpecifiers:(NSMutableArray *)specifiers {
 	NSMutableArray *specifiersToRemove = [NSMutableArray array];
 	NSMutableArray <NSString *> *twitterUsernames = [NSMutableArray array];
@@ -105,6 +172,14 @@
 				specifier.controllerLoadAction = specifier.buttonAction;
 			}
 		}
+
+		// allow SF Symbols to be used in .plist
+		// [specifier setProperty:[self imageSystemFromDict:specifier.properties[@"iconImageSystem"]] forKey:@"iconImage"];
+		// [specifier setProperty:[self imageSystemFromDict:specifier.properties[@"leftImageSystem"]] forKey:@"leftImage"];
+		// [specifier setProperty:[self imageSystemFromDict:specifier.properties[@"rightImageSystem"]] forKey:@"rightImage"];
+		specifier.properties[@"iconImage"] = [self imageSystemFromDict:specifier.properties[@"iconImageSystem"];
+		specifier.properties[@"leftImage"] = [self imageSystemFromDict:specifier.properties[@"leftImageSystem"];
+		specifier.properties[@"rightImage"] = [self imageSystemFromDict:specifier.properties[@"rightImageSystem"];
 	}
 
 	// if we have specifiers to remove

--- a/prefs/HBListController.m
+++ b/prefs/HBListController.m
@@ -61,7 +61,7 @@
 	return [self _hb_configureSpecifiers:specifiers];
 }
 
-- (NSInteger)symbolWeightWithString:(NSString *)weight {
+- (NSInteger)imageSystemWeight:(id)weight {
 	if ([weight isKindOfClass:NSNumber.class]) {
 		return [weight integerValue];
 	}


### PR DESCRIPTION
This PR will allow user to set a SFSymbols as property for specifier directly from .plist using
```xml
<key>iconImageSystem</key>
<dict>
  <key>name</key>
  <string>chevron.left.slash.chevron.right</string>
  <key>scale</key>
  <integer>1</integer> <-- or <string>small</string> or <string>UIImageSymbolScaleSmall</string> -->
  <key>weight</key>
  <integer>2</integer> <-- or <string>thin</string> or <string>UIImageSymbolWeightThin</string> -->
  <key>pointSize</key>
  <float>25.0</float>
</dict>
```

I'm not sure about the `imageSystemWeight` or `imageSystemScale` implementation, as it's very verbose, but as I'm not jailbroken atm, it's hard to test things out. It need to be tested for the same reason 😓 **Should** work tho. Also I wasn't sure about the syntax here `specifier.properties[@"iconImage"] = [self imageSystemFromDict:specifier.properties[@"iconImageSystem"];` so I left another one in comment, feel free to pick the one you want (or the one who works).