### PR TITLE
Implement Canister API for package icon lookup

### DIFF
--- a/prefs/HBListController+Actions.m
+++ b/prefs/HBListController+Actions.m
@@ -103,21 +103,18 @@
 	}
 
 	if ([UIAlertController class] != nil) {
-		NSURL *parcilityURL = [NSURL URLWithString:[@"https://parcility.co/package/" stringByAppendingString:escapedIdentifier]];
 		NSArray <NSArray <id> *> *packageManagerURLs = repo == nil
 			? @[
 				@[ @"com.saurik.Cydia", cydiaURL ],
 				@[ @"org.coolstar.SileoStore", [NSURL URLWithString:[@"sileo://package/" stringByAppendingString:escapedIdentifier]] ],
-				@[ @"xyz.willy.Zebra", [NSURL URLWithString:[@"zbra://package/" stringByAppendingString:escapedIdentifier]] ],
-				@[ @"com.apple.mobilesafari", parcilityURL ]
+				@[ @"xyz.willy.Zebra", [NSURL URLWithString:[@"zbra://package/" stringByAppendingString:escapedIdentifier]] ]
 			]
 			: @[
 				@[ @"com.saurik.Cydia", cydiaURL ],
 				@[ @"org.coolstar.SileoStore", [NSURL URLWithString:[@"sileo://package/" stringByAppendingString:escapedIdentifier]] ],
 				@[ @"xyz.willy.Zebra", [NSURL URLWithString:[NSString stringWithFormat:@"zbra://package/%@?%@", escapedIdentifier, @{
 						@"source": repo
-					}.hb_queryString]] ],
-				@[ @"com.apple.mobilesafari", parcilityURL ]
+					}.hb_queryString]] ]
 			];
 
 		NSString *title = LOCALIZE(@"OPEN_PACKAGE_IN_TITLE", @"PackageCell", @"");
@@ -133,13 +130,6 @@
 			}
 
 			NSString *name = app.localizedName;
-			if ([url.host isEqualToString:@"parcility.co"]) {
-				if (specifier.properties[@"_hb_parcilityReturnedNotFound"] != nil) {
-					continue;
-				}
-				name = @"Parcility";
-			}
-
 			UIImage *icon = [[UIImage _applicationIconImageForBundleIdentifier:bundleIdentifier format:MIIconVariantSmall scale:self.view.window.screen.scale] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
 			UIAlertAction *action = [UIAlertAction _actionWithTitle:name descriptiveText:nil image:icon style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
 				[self _hb_openURLInBrowser:url];

--- a/prefs/HBPackageTableCell.m
+++ b/prefs/HBPackageTableCell.m
@@ -56,8 +56,4 @@
 	return YES;
 }
 
-- (void)iconLoadDidFailWithResponse:(NSURLResponse *)response error:(NSError *)error {
-	[super iconLoadDidFailWithResponse:response error:error];
-}
-
 @end

--- a/prefs/HBPackageTableCell.m
+++ b/prefs/HBPackageTableCell.m
@@ -1,5 +1,6 @@
 #import "HBPackageTableCell.h"
 #import "HBPackage.h"
+#import "../NSDictionary+HBAdditions.h"
 #import <Preferences/PSSpecifier.h>
 #import <UIKit/UIImage+Private.h>
 #import <version.h>
@@ -20,16 +21,20 @@
 	}
 
 	if (specifier.properties[@"iconURL"] == nil) {
-		NSURL *iconURL = [[NSURL URLWithString:@"https://proxy.prcl.app/package/"] URLByAppendingPathComponent:_identifier];
-		NSString *iconField = getFieldForPackage(_identifier, @"Icon");
+		NSURL *iconURL = [NSURL URLWithString:[@"https://api.canister.me/v1/community/packages?" stringByAppendingString:@{
+			@"id": _identifier,
+			@"content": @"icon",
+			@"redirect": @"true"
+		}.hb_queryString]];
 
+		NSString *iconField = getFieldForPackage(_identifier, @"Icon");
 		if (iconField && ![iconField isEqualToString:@""]) {
 			NSURL *maybeIconURL = [NSURL URLWithString:iconField];
 			if (maybeIconURL != nil && (!maybeIconURL.isFileURL || [maybeIconURL checkResourceIsReachableAndReturnError:nil])) {
 				iconURL = maybeIconURL;
 			}
 		}
-		
+
 		specifier.properties[@"iconURL"] = iconURL;
 	}
 
@@ -52,7 +57,6 @@
 }
 
 - (void)iconLoadDidFailWithResponse:(NSURLResponse *)response error:(NSError *)error {
-	self.specifier.properties[@"_hb_parcilityReturnedNotFound"] = @YES;
 	[super iconLoadDidFailWithResponse:response error:error];
 }
 

--- a/prefs/Resources/DemoRoot.plist
+++ b/prefs/Resources/DemoRoot.plist
@@ -280,11 +280,11 @@
 			<key>cellClass</key>
 			<string>HBPackageTableCell</string>
 			<key>label</key>
-			<string>TypeStatus</string>
+			<string>TypeStatus Plus</string>
 			<key>subtitle</key>
-			<string>TypeStatus is also awesome!</string>
+			<string>TypeStatus Plus is also awesome!</string>
 			<key>packageIdentifier</key>
-			<string>ws.hbang.typestatus2</string>
+			<string>ws.hbang.typestatusplus</string>
 		</dict>
 		<dict>
 			<key>cellClass</key>


### PR DESCRIPTION
- Switch from using the Parcility Proxy API, to using the Canister API.
- I've also removed the Parcility Safari option in HBListController, for viewing package depictions because it's not really useful nor does it always provide the full depictions compared to a package manager.
- Preferences DemoRoot.plist file was changed so that it uses Typestatus Plus over Typestatus 2 for testing icon fetching.